### PR TITLE
Remove :build from llvm dep 

### DIFF
--- a/hhvm.rb
+++ b/hhvm.rb
@@ -18,7 +18,7 @@ class Hhvm < Formula
   # We need to build with upstream clang -- the version Apple ships doesn't
   # support TLS, which HHVM uses heavily. (And gcc compiles HHVM fine, but
   # causes ld to trip an assert and fail, for unclear reasons.)
-  depends_on "llvm" => [:build, "with-clang", "with-libcxx"]
+  depends_on "llvm" => ["with-clang", "with-libcxx"]
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
so hhvm will always depend on llvm libs instead of depending on them only for build process.
