### PR TITLE
Add jemalloc@4.5.0 formula

### DIFF
--- a/hhvm.rb
+++ b/hhvm.rb
@@ -37,6 +37,9 @@ class Hhvm < Formula
   # fibers api
   depends_on "boost"
 
+  # HHVM uses a jemalloc config option that was removed in 5.0.0
+  depends_on "jemalloc@4.5.0"
+
   depends_on "freetype"
   depends_on "gd"
   depends_on "gettext"
@@ -44,7 +47,6 @@ class Hhvm < Formula
   depends_on "gmp"
   depends_on "icu4c"
   depends_on "imagemagick@6"
-  depends_on "jemalloc"
   depends_on "jpeg"
   depends_on "libevent"
   depends_on "libmemcached"
@@ -100,7 +102,7 @@ class Hhvm < Formula
       -DENABLE_EXTENSION_MCROUTER=OFF
       -DENABLE_EXTENSION_IMAP=OFF
     ]
-    
+
     # Required to specify a socket path if you are using the bundled async SQL
     # client (which is very strongly recommended).
     cmake_args << "-DMYSQL_UNIX_SOCK_ADDR=/tmp/mysql.sock"

--- a/jemalloc@4.5.0.rb
+++ b/jemalloc@4.5.0.rb
@@ -1,0 +1,31 @@
+class JemallocAT450 < Formula
+  desc "malloc implementation emphasizing fragmentation avoidance"
+  homepage "http://www.canonware.com/jemalloc/"
+  url "https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2"
+  sha256 "9409d85664b4f135b77518b0b118c549009dc10f6cba14557d170476611f6780"
+  head "https://github.com/jemalloc/jemalloc.git"
+
+  def install
+    system "./configure", "--disable-debug", "--prefix=#{prefix}", "--with-jemalloc-prefix="
+    system "make"
+    system "make", "check"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<-EOS.undent
+      #include <stdlib.h>
+      #include <jemalloc/jemalloc.h>
+      int main(void) {
+        for (size_t i = 0; i < 1000; i++) {
+            // Leak some memory
+            malloc(i * 100);
+        }
+        // Dump allocator statistics to stderr
+        malloc_stats_print(NULL, NULL, NULL);
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-ljemalloc", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
jemalloc 5.0.0 removed the 'opt.lg_dirty_mult' option, resulting in a
(harmless) error message every time the hhvm process starts.

Fixes #87