### PR TITLE
Replace deprecated EOS.undent calls with builtin

### DIFF
--- a/hhvm-preview.rb
+++ b/hhvm-preview.rb
@@ -12,7 +12,7 @@ class HhvmPreview< Formula
     sha256 "b6a3b8d8e4feb98133ffaa12f87a42968fee824e186dc1ae206a67d92d8249d7" => :high_sierra
   end
 
-  option "with-debug", <<-EOS.undent
+  option "with-debug", <<~EOS
     Make an unoptimized build with assertions enabled. This will run PHP and
     Hack code dramatically slower than a release build, and is suitable mostly
     for debugging HHVM itself.
@@ -289,7 +289,7 @@ EOF
   end
 
   test do
-    (testpath/"test.php").write <<-EOS.undent
+    (testpath/"test.php").write <<~EOS
       <?php
       exit(is_integer(HHVM_VERSION_ID) ? 0 : 1);
     EOS
@@ -299,7 +299,7 @@ EOF
   plist_options :manual => "hhvm -m daemon -c #{HOMEBREW_PREFIX}/etc/hhvm/php.ini -c #{HOMEBREW_PREFIX}/etc/hhvm/server.ini"
 
   def plist
-    <<-EOS.undent
+    <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">
@@ -329,7 +329,7 @@ EOF
 
   # https://github.com/hhvm/packaging/blob/master/hhvm/deb/skeleton/etc/hhvm/php.ini
   def php_ini
-    <<-EOS.undent
+    <<~EOS
       ; php options
       session.save_handler = files
       session.save_path = #{var}/lib/hhvm/sessions
@@ -345,7 +345,7 @@ EOF
 
   # https://github.com/hhvm/packaging/blob/master/hhvm/deb/skeleton/etc/hhvm/server.ini
   def server_ini
-    <<-EOS.undent
+    <<~EOS
       ; php options
 
       pid = #{var}/run/hhvm/pid

--- a/hhvm.rb
+++ b/hhvm.rb
@@ -12,7 +12,7 @@ class Hhvm < Formula
     sha256 "40782b6d271d9f6cb5d1180e85a5d56c4a5b5ba0fafd20fa8c611209e23a7bea" => :high_sierra
   end
 
-  option "with-debug", <<-EOS.undent
+  option "with-debug", <<~EOS
     Make an unoptimized build with assertions enabled. This will run PHP and
     Hack code dramatically slower than a release build, and is suitable mostly
     for debugging HHVM itself.
@@ -287,7 +287,7 @@ EOF
   end
 
   test do
-    (testpath/"test.php").write <<-EOS.undent
+    (testpath/"test.php").write <<~EOS
       <?php
       exit(is_integer(HHVM_VERSION_ID) ? 0 : 1);
     EOS
@@ -297,7 +297,7 @@ EOF
   plist_options :manual => "hhvm -m daemon -c #{HOMEBREW_PREFIX}/etc/hhvm/php.ini -c #{HOMEBREW_PREFIX}/etc/hhvm/server.ini"
 
   def plist
-    <<-EOS.undent
+    <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">
@@ -327,7 +327,7 @@ EOF
 
   # https://github.com/hhvm/packaging/blob/master/hhvm/deb/skeleton/etc/hhvm/php.ini
   def php_ini
-    <<-EOS.undent
+    <<~EOS
       ; php options
       session.save_handler = files
       session.save_path = #{var}/lib/hhvm/sessions
@@ -343,7 +343,7 @@ EOF
 
   # https://github.com/hhvm/packaging/blob/master/hhvm/deb/skeleton/etc/hhvm/server.ini
   def server_ini
-    <<-EOS.undent
+    <<~EOS
       ; php options
 
       pid = #{var}/run/hhvm/pid

--- a/hhvm@3.21-lts.rb
+++ b/hhvm@3.21-lts.rb
@@ -12,7 +12,7 @@ class HhvmAT321Lts < Formula
     sha256 "e3bb0e14e04b7b301d4c4b7c24cb588038c4fb1b2a7709a0db4e816d5ec86607" => :high_sierra
   end
 
-  option "with-debug", <<-EOS.undent
+  option "with-debug", <<~EOS
     Make an unoptimized build with assertions enabled. This will run PHP and
     Hack code dramatically slower than a release build, and is suitable mostly
     for debugging HHVM itself.
@@ -287,7 +287,7 @@ EOF
   end
 
   test do
-    (testpath/"test.php").write <<-EOS.undent
+    (testpath/"test.php").write <<~EOS
       <?php
       exit(is_integer(HHVM_VERSION_ID) ? 0 : 1);
     EOS
@@ -297,7 +297,7 @@ EOF
   plist_options :manual => "hhvm -m daemon -c #{HOMEBREW_PREFIX}/etc/hhvm/php.ini -c #{HOMEBREW_PREFIX}/etc/hhvm/server.ini"
 
   def plist
-    <<-EOS.undent
+    <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">
@@ -327,7 +327,7 @@ EOF
 
   # https://github.com/hhvm/packaging/blob/master/hhvm/deb/skeleton/etc/hhvm/php.ini
   def php_ini
-    <<-EOS.undent
+    <<~EOS
       ; php options
       session.save_handler = files
       session.save_path = #{var}/lib/hhvm/sessions
@@ -343,7 +343,7 @@ EOF
 
   # https://github.com/hhvm/packaging/blob/master/hhvm/deb/skeleton/etc/hhvm/server.ini
   def server_ini
-    <<-EOS.undent
+    <<~EOS
       ; php options
 
       pid = #{var}/run/hhvm/pid


### PR DESCRIPTION
Fixes the following message encountered during the `brew update && brew upgrade` command:

   ```
   Warning: Calling <<-EOS.undent is deprecated!
   Use <<~EOS instead.
   ```