### PR TITLE
Unify the nightly and release build scripts

### DIFF
--- a/build-nightly.sh
+++ b/build-nightly.sh
@@ -2,29 +2,4 @@
 set -ex
 
 git pull --rebase
-brew list | grep hhvm | xargs brew uninstall --force || true
-brew upgrade
-cd Formula
-brew install --bottle-arch=nehalem --build-bottle ./hhvm-nightly.rb
-rm *.json || true
-brew bottle --force-core-tap --root-url=https://dl.hhvm.com/homebrew-bottles --json ./hhvm-nightly.rb
-# FIXME: Unsure what's intended here for now
-# See https://discourse.brew.sh/t/double-dash-bottle-naming-details/2712
-for file in *--*.bottle.tar.gz; do
-  mv "$file" "$(echo "$file" | sed s/--/-/)"
-done
-aws s3 sync ./ s3://hhvm-downloads/homebrew-bottles/ --exclude '*' --include '*.bottle.tar.gz'
-
-function commit_and_push_bottle() {
-  brew bottle --merge --keep-old --write --no-commit *.json
-  git add hhvm-nightly.rb
-  git commit -m "update bottle for nightly on $(sw_vers -productVersion)"
-  git push
-}
-
-if !(git pull --rebase && commit_and_push_bottle); then
-  git rebase --abort || true
-  git reset --hard origin/master
-  commit_and_push_bottle
-fi
-rm *.bottle.{tar.gz,json}
+NIGHTLY=true ./build-release $(date +%Y.m.%d)

--- a/update-nightly.sh
+++ b/update-nightly.sh
@@ -1,28 +1,6 @@
 #!/bin/bash
-set -ex
-DATE=$(date +%Y.%m.%d)
-URL="https://dl.hhvm.com/source/nightlies/hhvm-nightly-${DATE}.tar.gz"
 
-MYTEMP=$(mktemp -d)
-pushd $MYTEMP
-wget "$URL"
-wget "$URL.sig"
-gpg --verify *.sig
-SHA="$(openssl sha256 *.tar.gz | awk '{print $NF}')"
-popd
-rm -rf "$MYTEMP"
-
-git pull --rebase
-cd Formula
-# --dry-run: no git actions...
-# --write: ... but write to the local repo anyway
-brew bump-formula-pr \
-	--dry-run \
-	--write \
-	--url="${URL}" \
-	--sha256="${SHA}" \
-	./hhvm-nightly.rb
-gsed -i '/sha256.\+ => :/d' hhvm-nightly.rb
-git add hhvm-nightly.rb
-git commit -m 'Update nightly version'
-git push
+# Keeping this file for now so that the unificiation of release and nightly
+# builds can be undone with a single git revert, no crontab/infra changes.
+echo "Nothing to do."
+exit 0


### PR DESCRIPTION
Depends on - and currently includes - #124 

Current process:
- update-nightly.sh is ran by one worker and updates the source versions, and pushes
- both run build-nightly.sh, which builds, updates .rb file, resolves merge conflicts, and pushes

New process:
- both run `NIGHTLY=true ./build-release.sh $VERSION` which builds, updates .rb file resolves merge conflicts, and pushes