### PR TITLE
When commit/rebase/push fails, reset to previous rev

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -127,7 +127,10 @@ for file in *--*.bottle.tar.gz; do
 done
 aws s3 sync ./ s3://hhvm-downloads/homebrew-bottles/ --exclude '*' --include '*.bottle.tar.gz'
 
+PRE_BOTTLE_REV="$(git rev-parse HEAD)"
+
 function commit_and_push_bottle() {
+  git reset --hard "${PRE_BOTTLE_REV}"
   git pull origin master --rebase
   brew bottle --merge --keep-old --write --no-commit *.json
   git add "$RECIPE"


### PR DESCRIPTION
e.g. if we have the commit:

```
  bottle do
+   :high_sierra
  done
```

but master now has:

```
  bottle do
    :mojave
  done
```

the patch will fail to apply, and git won't be able to merge it.

Instead:
1. throw away the commit adding the new bottle
2. update to latest master using rebase
3. use `brew bottle --merge` to re-create the commit on new base

This should stop #126 from re-occurring.