### PR TITLE
Backport MacOS SDK fix to older releases

### DIFF
--- a/Formula/hhvm-4.32.rb
+++ b/Formula/hhvm-4.32.rb
@@ -78,7 +78,7 @@ class Hhvm432 < Formula
   depends_on "tbb"
 
   def install
-    cmake_args = %W[
+    cmake_args = std_cmake_args + %W[
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_INSTALL_SYSCONFDIR=#{etc}
       -DDEFAULT_CONFIG_DIR=#{etc}/hhvm

--- a/Formula/hhvm-4.48.rb
+++ b/Formula/hhvm-4.48.rb
@@ -78,7 +78,7 @@ class Hhvm448 < Formula
   depends_on "tbb"
 
   def install
-    cmake_args = %W[
+    cmake_args = std_cmake_args + %W[
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_INSTALL_SYSCONFDIR=#{etc}
       -DDEFAULT_CONFIG_DIR=#{etc}/hhvm

--- a/Formula/hhvm-4.49.rb
+++ b/Formula/hhvm-4.49.rb
@@ -78,7 +78,7 @@ class Hhvm449 < Formula
   depends_on "tbb"
 
   def install
-    cmake_args = %W[
+    cmake_args = std_cmake_args + %W[
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_INSTALL_SYSCONFDIR=#{etc}
       -DDEFAULT_CONFIG_DIR=#{etc}/hhvm

--- a/Formula/hhvm-4.50.rb
+++ b/Formula/hhvm-4.50.rb
@@ -77,7 +77,7 @@ class Hhvm450 < Formula
   depends_on "tbb"
 
   def install
-    cmake_args = %W[
+    cmake_args = std_cmake_args + %W[
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_INSTALL_SYSCONFDIR=#{etc}
       -DDEFAULT_CONFIG_DIR=#{etc}/hhvm

--- a/Formula/hhvm-4.8.rb
+++ b/Formula/hhvm-4.8.rb
@@ -78,7 +78,7 @@ class Hhvm48 < Formula
   depends_on "tbb"
 
   def install
-    cmake_args = %W[
+    cmake_args = std_cmake_args + %W[
       -DCMAKE_INSTALL_PREFIX=#{prefix}
       -DCMAKE_INSTALL_SYSCONFDIR=#{etc}
       -DDEFAULT_CONFIG_DIR=#{etc}/hhvm


### PR DESCRIPTION
This is a backport of b235998b164f6a81d77902a026379d53751f12d4

As of latest SDK, XCode and XCode Command Line Tools have incompatible
headers; make sure that cmake and homebrew agree on what to use.