### PR TITLE
Add aardvark_shell_utils as a build dependency, providing the CLI tool `realpath`

### DIFF
--- a/Formula/hhvm-nightly.rb
+++ b/Formula/hhvm-nightly.rb
@@ -37,6 +37,9 @@ class HhvmNightly < Formula
   depends_on "pkg-config" => :build
   depends_on "re2c" => :build
   depends_on "wget" => :build
+  
+  # Provides the CLI utility `realpath`
+  depends_on "aardvark_shell_utils" => :build
 
   # We statically link against icu4c as every non-bugfix release is not
   # backwards compatible; needing to rebuild for every release is too


### PR DESCRIPTION
The mac build fails constantly since https://github.com/facebook/hhvm/commit/8c8f1bad16e5b485fd94311df7031327bfcfb0b7, which uses the CLI tool `realpath`, which was not installed. This PR installs the required tool.