### PR TITLE
Use uutils-coreutils instead of aardvark_shell_utils

### DIFF
--- a/Formula/hhvm-nightly.rb
+++ b/Formula/hhvm-nightly.rb
@@ -39,7 +39,7 @@ class HhvmNightly < Formula
   depends_on "wget" => :build
   
   # Provides the CLI utility `realpath`
-  depends_on "aardvark_shell_utils" => :build
+  depends_on "uutils-coreutils" => :build
 
   # We statically link against icu4c as every non-bugfix release is not
   # backwards compatible; needing to rebuild for every release is too


### PR DESCRIPTION
uutils-coreutils is a new alternative to GNU's coreutils. It is better maintained than aardvark_shell_utils. Similar to aardvark_shell_utils, uutils-coreutils does not conflict with md5sha1sum.