### PR TITLE
Stop using `-j1` for hack target

### DIFF
--- a/Formula/hhvm-nightly.rb
+++ b/Formula/hhvm-nightly.rb
@@ -126,7 +126,7 @@ class HhvmNightly < Formula
     ]
 
     system "cmake", *cmake_args, '.'
-    system "make", "-j1", "hack", "hack_rust_ffi_bridge_targets"
+    system "make", "-j1", "hack_rust_ffi_bridge_targets"
     system "make" # pickups up -jN from MAKEFLAGS from brew
     system "make", "install"
 


### PR DESCRIPTION
We mostly need this to stop OOMing on rust builds, but now most of the
rust code is covered in FFI.

Our macos build jobs are spending ~ 1h in the -j1 part, so we should try
to limit it to the stuff where it's actually necessary

Test plan:

See what happens with tomorrow's nightly builds
