### PR TITLE
Add the dependency to fribidi

### DIFF
--- a/Formula/hhvm-4.128.rb
+++ b/Formula/hhvm-4.128.rb
@@ -44,6 +44,7 @@ class Hhvm4128 < Formula
   depends_on "boost"
   depends_on "double-conversion"
   depends_on "freetype"
+  depends_on "fribidi"
   depends_on "gd"
   depends_on "gettext"
   depends_on "glog"

--- a/Formula/hhvm-4.150.rb
+++ b/Formula/hhvm-4.150.rb
@@ -48,6 +48,7 @@ class Hhvm4150 < Formula
   depends_on "boost"
   depends_on "double-conversion"
   depends_on "freetype"
+  depends_on "fribidi"
   depends_on "gd"
   depends_on "gettext"
   depends_on "glog"

--- a/Formula/hhvm-4.151.rb
+++ b/Formula/hhvm-4.151.rb
@@ -48,6 +48,7 @@ class Hhvm4151 < Formula
   depends_on "boost"
   depends_on "double-conversion"
   depends_on "freetype"
+  depends_on "fribidi"
   depends_on "gd"
   depends_on "gettext"
   depends_on "glog"

--- a/Formula/hhvm-4.153.rb
+++ b/Formula/hhvm-4.153.rb
@@ -48,6 +48,7 @@ class Hhvm4153 < Formula
   depends_on "boost"
   depends_on "double-conversion"
   depends_on "freetype"
+  depends_on "fribidi"
   depends_on "gd"
   depends_on "gettext"
   depends_on "glog"


### PR DESCRIPTION
Recently the Github Actions fail constantly in hhvm/hhast.

https://github.com/hhvm/hhast/actions

One of the reason is missing dependency to fridibi.

This PR added the missing dependency.

Test Plan:
The hhast CI should pass, similar to https://github.com/Atry/hhast/blob/3c3c6aa23a02aa9eb232060f9462071ede284137/.github/workflows/build-and-test.yml