### PR TITLE
Add the dependency to krb5

### DIFF
--- a/Formula/hhvm-4.150.rb
+++ b/Formula/hhvm-4.150.rb
@@ -56,6 +56,7 @@ class Hhvm4150 < Formula
   depends_on "imagemagick@6"
   depends_on "jemalloc"
   depends_on "jpeg"
+  depends_on "krb5"
   depends_on "libevent"
   depends_on "libmemcached"
   depends_on "libsodium"

--- a/Formula/hhvm-4.151.rb
+++ b/Formula/hhvm-4.151.rb
@@ -56,6 +56,7 @@ class Hhvm4151 < Formula
   depends_on "imagemagick@6"
   depends_on "jemalloc"
   depends_on "jpeg"
+  depends_on "krb5"
   depends_on "libevent"
   depends_on "libmemcached"
   depends_on "libsodium"

--- a/Formula/hhvm-4.153.rb
+++ b/Formula/hhvm-4.153.rb
@@ -56,6 +56,7 @@ class Hhvm4153 < Formula
   depends_on "imagemagick@6"
   depends_on "jemalloc"
   depends_on "jpeg"
+  depends_on "krb5"
   depends_on "libevent"
   depends_on "libmemcached"
   depends_on "libsodium"

--- a/Formula/hhvm-4.154.rb
+++ b/Formula/hhvm-4.154.rb
@@ -56,6 +56,7 @@ class Hhvm4154 < Formula
   depends_on "imagemagick@6"
   depends_on "jemalloc"
   depends_on "jpeg"
+  depends_on "krb5"
   depends_on "libevent"
   depends_on "libmemcached"
   depends_on "libsodium"

--- a/Formula/hhvm-4.155.rb
+++ b/Formula/hhvm-4.155.rb
@@ -56,6 +56,7 @@ class Hhvm4155 < Formula
   depends_on "imagemagick@6"
   depends_on "jemalloc"
   depends_on "jpeg"
+  depends_on "krb5"
   depends_on "libevent"
   depends_on "libmemcached"
   depends_on "libsodium"

--- a/Formula/hhvm-4.156.rb
+++ b/Formula/hhvm-4.156.rb
@@ -56,6 +56,7 @@ class Hhvm4156 < Formula
   depends_on "imagemagick@6"
   depends_on "jemalloc"
   depends_on "jpeg"
+  depends_on "krb5"
   depends_on "libevent"
   depends_on "libmemcached"
   depends_on "libsodium"

--- a/Formula/hhvm-nightly.rb
+++ b/Formula/hhvm-nightly.rb
@@ -56,6 +56,7 @@ class HhvmNightly < Formula
   depends_on "imagemagick@6"
   depends_on "jemalloc"
   depends_on "jpeg"
+  depends_on "krb5"
   depends_on "libevent"
   depends_on "libmemcached"
   depends_on "libsodium"


### PR DESCRIPTION
`krb5` is used according to
https://github.com/facebook/hhvm/blob/44c66611211a059dc8bb95392a197ad98b1ba72a/CMake/HPHPFindLibs.cmake#L301

