### PR TITLE
Revert "Revert incomplete bottle #152"

### DIFF
--- a/Formula/hhvm-4.159.rb
+++ b/Formula/hhvm-4.159.rb
@@ -13,7 +13,6 @@ class Hhvm4159 < Formula
 
   bottle do
     root_url "https://dl.hhvm.com/homebrew-bottles"
-    sha256 catalina: "f2a61316967b82b0ac2dc5f4c7fa995cc82d0f5ea3397c09ef8f965450612c75"
   end
 
   option "with-debug", <<~EOS

--- a/Formula/hhvm-4.159.rb
+++ b/Formula/hhvm-4.159.rb
@@ -13,6 +13,7 @@ class Hhvm4159 < Formula
 
   bottle do
     root_url "https://dl.hhvm.com/homebrew-bottles"
+    sha256 catalina: "26379e68f39d059dcce7d58cb97c3f251de0dc17d4e6f0b7ca1618502ddcbee5"
   end
 
   option "with-debug", <<~EOS


### PR DESCRIPTION
I landed #152 because the Homebrew bottle `26379e68f39d059dcce7d58cb97c3f251de0dc17d4e6f0b7ca1618502ddcbee5` is not uploaded to dl.hhvm.com while the hash is updated. However, the bottle seems now uploaded finally. This PR reverts #152 to keep the hash code consistent